### PR TITLE
Unterstützung der Signatur mehrseitiger PDF-Dateien

### DIFF
--- a/falsisign.sh
+++ b/falsisign.sh
@@ -8,6 +8,7 @@ DOCUMENT=$1
 SIGNATURES=signatures
 GEO=$2
 OUTPUT=$3
+SIGNPAGE=${4:-1}
 DOCUMENT_BN=$(basename "${DOCUMENT}" .pdf)
 TMPDIR=/tmp/falsisign-${RANDOM}
 
@@ -20,8 +21,10 @@ trap cleanUp 0 1 2 3 4 5 6 7 8 9 10 12 13 14 15
 mkdir ${TMPDIR}
 
 # Aktuell verarbeiten wir nur einseitige Dokumente!
-gs -sDEVICE=png16m -dTextAlphaBits=4 -r100 -o ${TMPDIR}/tmp.png "${DOCUMENT}"
-SIGNATURE=$(find "${SIGNATURES}" -name '*.png' | shuf -n 1)
-convert "${TMPDIR}/tmp.png" "${SIGNATURE}" -geometry "${GEO}" +profile '*' -composite "${TMPDIR}/${DOCUMENT_BN}"-signed.jpeg
-gs -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -dSAFER -sOutputFile="${OUTPUT}" viewjpeg.ps -c "(${TMPDIR}/${DOCUMENT_BN}-signed.jpeg) viewJPEG showpage"
+gs -sDEVICE=png16m -dTextAlphaBits=4 -r100 -o ${TMPDIR}/tmp-%d.png "${DOCUMENT}"
+SIGNATURE=$(find "${SIGNATURES}/" -name '*.png' | shuf -n 1)
+
+convert "${TMPDIR}/tmp-${SIGNPAGE}.png" "${SIGNATURE}" -geometry "${GEO}" +profile '*' -composite "${TMPDIR}/tmp-${SIGNPAGE}"-signed.png
+rm "${TMPDIR}/tmp-${SIGNPAGE}.png"
+convert -format pdf -density 100 -units PixelsPerInch "${TMPDIR}/tmp-*.png" out.pdf
 cleanUp


### PR DESCRIPTION
Wie der Betreff sagt: Der PR setzt die Unterstützung der Signatur mehrseitiger PDF-Dateien um und führt dafür einen vierten (optionalen) Parameter ein. Wird dieser nicht angegeben, wird weiterhin die erste Seite signiert. Wird er angegeben, wird die angegebene Seite signiert.

Für den Effekt wurde die PDF-Ausgabe durch Imagemagick ersetzt.